### PR TITLE
Add L40 GPUs to Ondemand

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -46,19 +46,15 @@ form:
   - bc_num_hours
   - jupyterlab_switch
   - bc_email_on_started
-  - extra_commands
 attributes:
   version:
     widget: select
     label: "Jupyter version"
     help: "This defines the version of Jupyter you want to load."
+    value: "jupyter/5.0.0"
     options:
-      - [
-          "4.9.2", "jupyter/4.9.2",
-        ]
-      - [
-          "5.0.0", "jupyter/5.0.0",
-        ]
+      - [ "4.9.2", "jupyter/4.9.2" ]
+      - [ "5.0.0", "jupyter/5.0.0" ]
   custom_queue:
     label: Partition
     widget: select
@@ -101,6 +97,7 @@ attributes:
         - [
             "<%= q %>", "<%= q %>",
             data-max-num-cores: <%= maxcore %>,
+            data-set-num-cores: <%= maxcore %>,
             <%- if !gpu -%>
             data-hide-enable-gpu: true,
             data-set-enable-gpu: 0
@@ -112,24 +109,16 @@ attributes:
   # Any extra command line arguments to feed to the `jupyter notebook ...`
   # command that launches the Jupyter notebook within the batch job
   extra_jupyter_args: ""
-  extra_commands:
-    widget: text_area
-    label: "Additional commands to run"
-    help: |
-      Additional commands to run, e.g., loading a module or setting an
-      environment variable. If you're not sure, just leave this blank.
   num_cores:
     widget: number_field
     label: "Number of cores"
-    value: 1
     min: 1
     max: 1
   enable_gpu:
     widget: check_box
     label: "Enable GPU"
-    help:
   bc_num_hours:
-    value: 1
+    value: 4
     min: 1
     max: 4
   jupyterlab_switch:

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,9 +1,9 @@
 <%-
 require 'open3'
 begin
-    oodqueues = ['classroomgpu', 'cryogars', 'ondemand', 'ondemand-p100']
-    maxcores = [14, 32, 4, 14]
-    hasgpu = [true, true, false, true]
+    oodqueues = ['classroomgpu', 'cryogars', 'ondemand', 'ondemand-p100', 'ondemand-l40']
+    maxcores = [14, 32, 4, 14, 16]
+    hasgpu = [true, true, false, true, true]
     # Command to Run
     script = '/cm/shared/apps/slurm/current/bin/sinfo -h --format="%P"'
     # Create a partitions array to dynamically populate the queues associated
@@ -65,11 +65,11 @@ attributes:
     help: |
     <%- if partitions.include?("classroomgpu")-%>
       - **classroomgpu** <br>
-        These are HPC nodes with 2 [NVIDIA Tesla P100 GPUs], 28 cores, and
-        251 GB of memory.
+        These nodes have 2 [NVIDIA Tesla P100 GPUs], 28 cores, and 251 GB of
+        memory.
         By selecting the "classroomgpu" partition, you will be given up to 14
         cores and 1 GPU.
-        [NVIDIA Tesla P100 GPUs]: http://www.nvidia.com/object/tesla-p100.html
+        [NVIDIA Tesla P100 GPUs]: https://www.nvidia.com/en-in/data-center/tesla-p100/
     <%- end -%>
     <%- if partitions.include?("cryogars")-%>
       - **cryogars** <br>
@@ -79,14 +79,19 @@ attributes:
         [NVIDIA A30 GPUs]: https://www.nvidia.com/a30
     <%- end -%>
       - **ondemand** <br>
-        Standard Borah nodes have 48 cores and 186 GB of memory.
+        These nodes have 48 cores and 186 GB of memory.
         By selecting the "ondemand" partition, you will be given up to 4 cores.
       - **ondemand-p100** <br>
-        These are HPC nodes with 2 [NVIDIA Tesla P100 GPUs], 28 cores, and
-        251 GB of memory.
+        These nodes have 2 [NVIDIA Tesla P100 GPUs], 28 cores, and 251 GB of
+        memory.
         By selecting the "ondemand-p100" partition, you will be given up to 14
         cores and 1 GPU.
-        [NVIDIA Tesla P100 GPUs]: http://www.nvidia.com/object/tesla-p100.html
+        [NVIDIA Tesla P100 GPUs]: https://www.nvidia.com/en-in/data-center/tesla-p100/
+      - **ondemand-l40** <br>
+        These nodes have 4 [NVIDIA L40 GPUs], 64 cores, and 512 GB of memory.
+        By selecting the "ondemand-l40" partition, you will be given up to 16
+        cores and 1 GPU.
+        [NVIDIA L40 GPUs]: https://www.nvidia.com/en-us/data-center/l40/
     <%- if partition_error || partitions.blank?-%>
       <div class="text-danger">Error while fetching Partition. Please contact
       support!</div>

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,38 +1,40 @@
 <%-
 require 'open3'
 begin
-    oodqueues = ['classroomgpu', 'cryogars', 'ondemand', 'ondemand-p100', 'ondemand-l40']
-    maxcores = [14, 32, 4, 14, 16]
-    hasgpu = [true, true, false, true, true]
-    # Command to Run
-    script = '/cm/shared/apps/slurm/current/bin/sinfo -h --format="%P"'
-    # Create a partitions array to dynamically populate the queues associated
-    # with the user
-    partitions = []
-    pmaxcores = []
-    phasgpu = []
-    # Store the output, error, status
-    output, status = Open3.capture2('bash', stdin_data: script)
-    # puts status
-    if status.success?
-        # Add it to the custom_envs array by splitting the output at '\n'.
-        output.split("\n").each do |queue|
-            if oodqueues.include?(queue)
-                qindex = oodqueues.index(queue)
-                queue = queue.gsub("*", "")
-                partitions.push(queue)
-                pmaxcores.push(maxcores[qindex])
-                phasgpu.push(hasgpu[qindex])
-            end
-        end
-        puts partitions
-        puts pmaxcores
-        puts phasgpu
-    else
-        partition_error = "Error"
+  oodqueues = [
+    'classroomgpu', 'cryogars', 'ondemand', 'ondemand-l40', 'ondemand-p100'
+  ]
+  maxcores = [14, 32, 4, 16, 14]
+  hasgpu = [true, true, false, true, true]
+  # Command to Run
+  script = '/cm/shared/apps/slurm/current/bin/sinfo -h --format="%P"'
+  # Create a partitions array to dynamically populate the queues associated
+  # with the user
+  partitions = []
+  pmaxcores = []
+  phasgpu = []
+  # Store the output, error, status
+  output, status = Open3.capture2('bash', stdin_data: script)
+  # puts status
+  if status.success?
+    # Add it to the custom_envs array by splitting the output at '\n'.
+    output.split("\n").each do |queue|
+      if oodqueues.include?(queue)
+        qindex = oodqueues.index(queue)
+        queue = queue.gsub("*", "")
+        partitions.push(queue)
+        pmaxcores.push(maxcores[qindex])
+        phasgpu.push(hasgpu[qindex])
+      end
     end
+    puts partitions
+    puts pmaxcores
+    puts phasgpu
+  else
+    partition_error = "Error"
+  end
 rescue => e
-    partition_error = e.message.strip
+  partition_error = e.message.strip
 end
 -%>
 ---

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,32 +1,11 @@
 <%-
   nodes = bc_num_slots.blank? ? 1 : bc_num_slots.to_i
 
-  case custom_queue
-  when "ondemand-p100"
-    slurm_args = [
-      "--nodes", "#{nodes}",
-      "-c", "#{num_cores}",
-      "--partition", "ondemand-p100"
-    ]
-  when "classroomgpu"
-    slurm_args = [
-      "--nodes", "#{nodes}",
-      "-c", "#{num_cores}",
-      "--partition", "classroomgpu"
-    ]
-  when "cryogars"
-    slurm_args = [
-      "--nodes", "#{nodes}",
-      "-c", "#{num_cores}",
-      "--partition", "cryogars"
-    ]
-  else
-    slurm_args = [
-      "--nodes", "#{nodes}",
-      "-c", "#{num_cores}",
-      "--partition", "ondemand"
-    ]
-  end
+  slurm_args = [
+    "--nodes", "#{nodes}",
+    "-c", "#{num_cores}",
+    "--partition", "#{custom_queue}"
+  ]
   if enable_gpu == "1"
     slurm_args += ["--gpus-per-node", "1"]
   end

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -18,10 +18,6 @@ module purge
 module load <%= context.version %> slurm
 <%- end -%>
 
-<%- unless context.extra_commands.blank? -%>
-<%= context.extra_commands %>
-<%- end -%>
-
 # List loaded modules
 module list
 


### PR DESCRIPTION
- Add ondemand-l40 queue
- Remove the "additional commands to run". I originally added this so users could load arbitrary modules, but I think it was insecurely implemented...